### PR TITLE
Reduce production of redundant strip segments

### DIFF
--- a/lib/filter_scene.py
+++ b/lib/filter_scene.py
@@ -191,7 +191,7 @@ def isValidArggroups(arggroup_list):
 
 
 def generateMasks(demFile, mask_version, dstdir=None, noentropy=False, nbit_masks=False,
-                  save_component_masks=MASK_SEPARATE, debug_component_masks=DEBUG_NONE,
+                  save_component_masks=None, debug_component_masks=DEBUG_NONE,
                   use_second_ortho=False, use_pil_imresize=False):
     """
     Create and save scene masks that mask ON regions of bad data.
@@ -261,11 +261,14 @@ def generateMasks(demFile, mask_version, dstdir=None, noentropy=False, nbit_mask
         if mask_version.endswith('maskv1'):
             masks = mask_v1(demFile, noentropy, image_num=image_num)
         else:
-            if True in [mask_version.endswith(name) for name in ['mask', 'bitmask', 'maskv2_debug']]:
-                if mask_version == 'mask':
-                    save_component_masks = MASK_FLAT
-                elif mask_version == 'bitmask':
-                    save_component_masks = MASK_BIT
+            if mask_version.endswith(('bitmask', 'mask', 'maskv2_debug')):
+                if save_component_masks is None:
+                    if mask_version.endswith('bitmask'):
+                        save_component_masks = MASK_BIT
+                    elif mask_version.endswith('mask'):
+                        save_component_masks = MASK_FLAT
+                    elif mask_version.endswith('maskv2_debug'):
+                        save_component_masks = MASK_SEPARATE
                 mask = mask_v2(demFile, mask_version,
                                save_component_masks=(save_component_masks != MASK_FLAT),
                                debug_component_masks=debug_component_masks,
@@ -275,7 +278,7 @@ def generateMasks(demFile, mask_version, dstdir=None, noentropy=False, nbit_mask
             elif mask_version.endswith('mask8m'):
                 mask = mask8m(demFile)
             else:
-                raise InvalidArgumentError("`mask_version` must be one of {}, "
+                raise InvalidArgumentError("`mask_version` must end with one of {}, "
                                            "but was {}".format(suffix_choices, mask_version))
 
             if type(mask) == dict:

--- a/lib/scenes2strips.py
+++ b/lib/scenes2strips.py
@@ -928,8 +928,9 @@ def loadData(demFile, matchFile, orthoFile, ortho2File, maskFile, metaFile):
                 warnings.warn("Ortho{} '{}' dimensions differ from DEM dimensions".format(ortho_num if ortho_num > 1 else '', ortho_file)
                              +"\nInterpolating to DEM dimensions")
                 x, y = rat.extractRasterData(rat.openRaster(ortho_file, __STRIP_SPAT_REF__, 'bicubic'), 'x', 'y')
+                o = o.astype(np.float32)
                 o[o == 0] = np.nan  # Set border to NaN so it won't be interpolated.
-                o = rat.interp2_gdal(x, y, o.astype(np.float32), x_dem, y_dem, 'cubic')
+                o = rat.interp2_gdal(x, y, o, x_dem, y_dem, 'cubic')
                 o[np.isnan(o)] = 0  # Convert back to uint16.
                 o = rat.astype_round_and_crop(o, np.uint16, allow_modify_array=True)
         ortho_arrays.append(o)

--- a/lib/scenes2strips.py
+++ b/lib/scenes2strips.py
@@ -1118,7 +1118,7 @@ def applyMasks(x, y, z, m, o, o2, md, filter_options=(), maskSuffix=None):
 
     mask_select = (mask_select > 0)
 
-    if maskSuffix in ('mask.tif', 'bitmask.tif'):
+    if maskSuffix.endswith(('mask.tif', 'bitmask.tif')):
         mask_select = mask_v2(postprocess_mask=mask_select, postprocess_res=abs(x[1]-x[0]))
 
     z[mask_select] = np.nan


### PR DESCRIPTION
Many redundant strip segments could result from small DEM scene "slivers" PGC created as part of regular DEM production through 2021, when we will start reducing production of these sliver DEMs.

Adjusted strip segmentation logic to consider small DEM scenes that were "skipped over" during assembly of the current strip segment, before starting on the next strip segment.