### PR TITLE
Improve LZW compression of written rasters

### DIFF
--- a/batch_scenes2strips.py
+++ b/batch_scenes2strips.py
@@ -1592,6 +1592,7 @@ def saveStripBrowse(args, demFile, demSuffix, maskSuffix):
     ortho2File_10m     = demFile.replace(demSuffix, 'ortho2_10m.tif')
     matchFile_10m      = demFile.replace(demSuffix, 'matchtag_10m.tif')
     demFile_10m        = demFile.replace(demSuffix, 'dem_10m.tif')
+    demFile_10m_temp   = demFile.replace(demSuffix, 'dem_10m_temp.tif')
     demFile_10m_masked = demFile.replace(demSuffix, 'dem_10m_masked.tif')
     demFile_10m_shade  = demFile.replace(demSuffix, 'dem_10m_shade.tif')
     demFile_shade_mask = demFile.replace(demSuffix, 'dem_10m_shade_masked.tif')
@@ -1605,6 +1606,7 @@ def saveStripBrowse(args, demFile, demSuffix, maskSuffix):
         output_files.update([
             maskFile_10m,
             demFile_10m,
+            demFile_10m_temp,
             demFile_10m_shade,
             demFile_shade_mask
         ])
@@ -1620,6 +1622,7 @@ def saveStripBrowse(args, demFile, demSuffix, maskSuffix):
             orthoFile_10m,
             matchFile_10m,
             demFile_10m,
+            demFile_10m_temp,
             demFile_10m_shade,
             demFile_10m_masked,
             demFile_shade_mask,
@@ -1669,7 +1672,11 @@ def saveStripBrowse(args, demFile, demSuffix, maskSuffix):
     if demFile_10m in output_files:
         commands.append(
             ('gdalwarp "{0}" "{1}" -q -overwrite -tr {2} {2} -r bilinear -dstnodata -9999'
-             ' -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW'.format(demFile, demFile_10m, 10))
+             ' -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW'.format(demFile, demFile_10m_temp, 10))
+        )
+        commands.append(
+            ('gdal_calc.py --quiet --overwrite -A "{0}" --outfile="{1}" --calc="round_(A*128.0)/128.0" --NoDataValue=-9999'
+             ' --co TILED=YES --co BIGTIFF=IF_SAFER --co COMPRESS=LZW --co PREDICTOR=3'.format(demFile_10m_temp, demFile_10m))
         )
     if demFile_10m_shade in output_files:
         commands.append(

--- a/batch_scenes2strips.py
+++ b/batch_scenes2strips.py
@@ -1657,12 +1657,12 @@ def saveStripBrowse(args, demFile, demSuffix, maskSuffix):
     if orthoFile_10m in output_files:
         commands.append(
             ('gdalwarp "{0}" "{1}" -q -overwrite -tr {2} {2} -r cubic -dstnodata 0'
-             ' -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW'.format(orthoFile, orthoFile_10m, 10))
+             ' -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW -co PREDICTOR=2'.format(orthoFile, orthoFile_10m, 10))
         )
     if ortho2File_10m in output_files:
         commands.append(
             ('gdalwarp "{0}" "{1}" -q -overwrite -tr {2} {2} -r cubic -dstnodata 0'
-             ' -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW'.format(ortho2File, ortho2File_10m, 10))
+             ' -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW -co PREDICTOR=2'.format(ortho2File, ortho2File_10m, 10))
         )
     if matchFile_10m in output_files:
         commands.append(

--- a/lib/raster_array_tools.py
+++ b/lib/raster_array_tools.py
@@ -669,9 +669,11 @@ def saveArrayAsTiff(array, dest,
         Creation Option arguments to pass to the `Create` method of the GDAL
         Geotiff driver that instantiates the output raster dataset.
         If 'compress', the following default arguments are used:
+          'TILED=YES'
           'BIGTIFF=IF_SAFER'
           'COMPRESS=LZW'
-          'TILED=YES'
+          'PREDICTOR=X' (where `X` is automatically derived from input and
+                         output array data types)
         The 'NBITS=X' argument may not be used -- that is set by the `nbits`
         argument for this function.
         A list of Creation Option arguments may be found here: [1].
@@ -729,7 +731,7 @@ def saveArrayAsTiff(array, dest,
                                                "Please use this function's `nbits` argument.")
 
     shape = array.shape
-    dtype_gdal = None
+    dtype_out_gdal = None
     if like_raster is not None:
         ds_like = openRaster(like_raster)
         if shape[0] != ds_like.RasterYSize or shape[1] != ds_like.RasterXSize:
@@ -743,7 +745,7 @@ def saveArrayAsTiff(array, dest,
         if nodata_val == 'like_raster':
             nodata_val = extractRasterData(ds_like, 'nodata_val')
         if dtype_out is None:
-            dtype_gdal = extractRasterData(ds_like, 'dtype_val')
+            dtype_out_gdal = extractRasterData(ds_like, 'dtype_val')
     else:
         if shape[0] != Y.size or shape[1] != X.size:
             raise InvalidArgumentError("Lengths of [`Y`, `X`] grid coordinates ({}, {}) do not match "
@@ -754,6 +756,18 @@ def saveArrayAsTiff(array, dest,
     if nodata_val == 'like_raster':
         nodata_val = None
 
+    dtype_in_np = array.dtype
+
+    dtype_in_general = None
+    dtype_out_general = None
+
+    if dtype_in_np == bool:
+        dtype_in_general = 'bool'
+    elif np.issubdtype(dtype_in_np, np.integer):
+        dtype_in_general = 'int'
+    elif np.issubdtype(dtype_in_np, np.floating):
+        dtype_in_general = 'float'
+
     if dtype_out is not None:
         if dtype_is_nbits:
             if nbits is None:
@@ -761,41 +775,62 @@ def saveArrayAsTiff(array, dest,
             elif type(nbits) != int or nbits < 1:
                 raise InvalidArgumentError("`nbits` must be an integer in the range [1,32]")
             if nbits <= 8:
-                dtype_gdal = gdal.GDT_Byte
+                dtype_out_gdal = gdal.GDT_Byte
             elif nbits <= 16:
-                dtype_gdal = gdal.GDT_UInt16
+                dtype_out_gdal = gdal.GDT_UInt16
             elif nbits <= 32:
-                dtype_gdal = gdal.GDT_UInt32
+                dtype_out_gdal = gdal.GDT_UInt32
             else:
                 raise InvalidArgumentError("Output array requires {} bits of precision, "
                                            "but GDAL supports a maximum of 32 bits")
+            dtype_out_general = 'int'
         else:
             if type(dtype_out) is str:
                 dtype_out = eval('np.{}'.format(dtype_out.lower()))
-            dtype_gdal = gdal_array.NumericTypeCodeToGDALTypeCode(dtype_out)
-            if dtype_gdal is None:
+            dtype_out_gdal = gdal_array.NumericTypeCodeToGDALTypeCode(dtype_out)
+            if dtype_out_gdal is None:
                 raise InvalidArgumentError("Output array data type ({}) does not have equivalent "
                                            "GDAL data type and is not supported".format(dtype_out))
+            if np.issubdtype(dtype_out, np.integer):
+                dtype_out_general = 'int'
+            elif np.issubdtype(dtype_out, np.floating):
+                dtype_out_general = 'float'
 
-    dtype_in = array.dtype
-    dtype_in_gdal, promote_dtype = dtype_np2gdal(dtype_in)
+    dtype_in_gdal, promote_dtype = dtype_np2gdal(dtype_in_np)
     if promote_dtype is not None:
         array = array.astype(promote_dtype)
-        dtype_in = promote_dtype(1).dtype
+        dtype_in_np = promote_dtype(1).dtype
+
+    if dtype_out_general is None:
+        if np.issubdtype(dtype_in_np, np.integer):
+            dtype_out_general = 'int'
+        elif np.issubdtype(dtype_in_np, np.floating):
+            dtype_out_general = 'float'
+
     if dtype_out is not None:
         if dtype_is_nbits:
-            if not np.issubdtype(dtype_in, np.unsignedinteger):
+            if not np.issubdtype(dtype_in_np, np.unsignedinteger):
                 warn("Input array data type ({}) is not unsigned and may be incorrectly saved "
-                     "with n-bit precision".format(dtype_in))
-        elif dtype_in != dtype_out:
+                     "with n-bit precision".format(dtype_in_np))
+        elif dtype_in_np != dtype_out:
             warn("Input array NumPy data type ({}) differs from output "
-                 "NumPy data type ({})".format(dtype_in, dtype_out(1).dtype))
-    elif dtype_gdal is not None and dtype_gdal != dtype_in_gdal:
+                 "NumPy data type ({})".format(dtype_in_np, dtype_out(1).dtype))
+    elif dtype_out_gdal is not None and dtype_out_gdal != dtype_in_gdal:
         warn("Input array GDAL data type ({}) differs from output "
              "GDAL data type ({})".format(gdal.GetDataTypeName(dtype_in_gdal),
-                                          gdal.GetDataTypeName(dtype_gdal)))
-    if dtype_gdal is None:
-        dtype_gdal = dtype_in_gdal
+                                          gdal.GetDataTypeName(dtype_out_gdal)))
+    if dtype_out_gdal is None:
+        dtype_out_gdal = dtype_in_gdal
+
+    if co_args == 'compress':
+        compress_predictor = 1
+        if dtype_in_general == 'bool':
+            compress_predictor = 1
+        elif dtype_out_general == 'int':
+        # elif dtype_out_general == 'int' or dtype_in_general == 'int':
+            compress_predictor = 2
+        elif dtype_out_general == 'float':
+            compress_predictor = 3
 
     sys.stdout.write("Saving Geotiff {} ...".format(dest))
     sys.stdout.flush()
@@ -805,10 +840,11 @@ def saveArrayAsTiff(array, dest,
         co_args = []
     if co_args == 'compress':
         co_args = []
+        co_args.extend(['TILED=YES'])         # Force creation of tiled TIFF files.
         co_args.extend(['BIGTIFF=IF_SAFER'])  # Will create BigTIFF
                                               # if the resulting file *might* exceed 4GB.
         co_args.extend(['COMPRESS=LZW'])      # Do LZW compression on output image.
-        co_args.extend(['TILED=YES'])         # Force creation of tiled TIFF files.
+        co_args.extend(['PREDICTOR={}'.format(compress_predictor)])
     if dtype_is_nbits:
         co_args.extend(['NBITS={}'.format(nbits)])
 
@@ -818,14 +854,14 @@ def saveArrayAsTiff(array, dest,
         if projstr_proj4 is None:
             projstr_proj4 = spat_ref.ExportToProj4()
     sys.stdout.write(" GDAL data type: {}, NoData value: {}, Creation Options: {}, Projection (Proj4): {} ...".format(
-        gdal.GetDataTypeName(dtype_gdal), nodata_val, ' '.join(co_args) if co_args else None, projstr_proj4.strip())
+        gdal.GetDataTypeName(dtype_out_gdal), nodata_val, ' '.join(co_args) if co_args else None, projstr_proj4.strip())
     )
     sys.stdout.flush()
 
     sys.stdout.write(" creating file ...")
     sys.stdout.flush()
     driver = gdal.GetDriverByName('GTiff')
-    ds_out = driver.Create(dest, shape[1], shape[0], 1, dtype_gdal, co_args)
+    ds_out = driver.Create(dest, shape[1], shape[0], 1, dtype_out_gdal, co_args)
     ds_out.SetGeoTransform(geo_trans)
     if projstr_wkt is not None:
         ds_out.SetProjection(projstr_wkt)

--- a/lib/scenes2strips.py
+++ b/lib/scenes2strips.py
@@ -658,6 +658,12 @@ def scenes2strips(demFiles,
             O  =  O[rcrop[0]:rcrop[1], ccrop[0]:ccrop[1]]
             O2 = O2[rcrop[0]:rcrop[1], ccrop[0]:ccrop[1]] if O2 is not None else None
             MD = MD[rcrop[0]:rcrop[1], ccrop[0]:ccrop[1]]
+
+            # Round DEM values to 1/128 to greatly improve compression effectiveness
+            np.multiply(Z, 128.0, out=Z)
+            np.round_(Z, decimals=0, out=Z)
+            np.divide(Z, 128.0, out=Z)
+
             Z[np.isnan(Z)] = -9999
     else:
         X, Y, Z, M, O, O2, MD = None, None, None, None, None, None, None

--- a/reproject_setsm.py
+++ b/reproject_setsm.py
@@ -855,12 +855,12 @@ def saveStripBrowse(args, demFile, demSuffix, maskSuffix):
     if orthoFile_10m in output_files:
         commands.append(
             ('gdalwarp "{0}" "{1}" -q -overwrite -tr {2} {2} -r cubic -dstnodata 0'
-             ' -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW'.format(orthoFile, orthoFile_10m, 10))
+             ' -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW -co PREDICTOR=2'.format(orthoFile, orthoFile_10m, 10))
         )
     if ortho2File_10m in output_files:
         commands.append(
             ('gdalwarp "{0}" "{1}" -q -overwrite -tr {2} {2} -r cubic -dstnodata 0'
-             ' -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW'.format(ortho2File, ortho2File_10m, 10))
+             ' -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW -co PREDICTOR=2'.format(ortho2File, ortho2File_10m, 10))
         )
     if matchFile_10m in output_files:
         commands.append(

--- a/reproject_setsm.py
+++ b/reproject_setsm.py
@@ -618,6 +618,8 @@ def reproject_setsm(src_metafile, dstdir=None, target_epsg=None, target_resoluti
 
     for rasterfile_src in src_rasters_to_reproject:
         rasterfile_dst = os.path.join(dstdir, os.path.basename(rasterfile_src))
+        rasterfile_dst_uncompressed = None
+
         if args.get(ARGSTR_ADD_RES_SUFFIX):
             rasterfile_dst_base, rasterfile_dst_ext = os.path.splitext(rasterfile_dst)
             rasterfile_dst = "{}_{}m{}".format(
@@ -625,6 +627,13 @@ def reproject_setsm(src_metafile, dstdir=None, target_epsg=None, target_resoluti
             )
         rasterfile_dst_res = (target_resolution if target_resolution is not None else
                               raster_io.extractRasterData(rasterfile_src, 'res'))
+
+        if rasterfile_src.endswith('dem.tif'):
+            rasterfile_dst_base, rasterfile_dst_ext = os.path.splitext(rasterfile_dst)
+            rasterfile_dst_uncompressed = "{}_uncompressed{}".format(
+                rasterfile_dst_base, rasterfile_dst_ext
+            )
+
         resample_method = None
         for suffix_key, suffix_method in SETSM_SUFFIX_KEY_TO_RESAMPLE_METHOD_LOOKUP:
             if suffix_key in rasterfile_src:
@@ -635,15 +644,31 @@ def reproject_setsm(src_metafile, dstdir=None, target_epsg=None, target_resoluti
                 "No suffix key in `SETSM_SUFFIX_KEY_TO_RESAMPLE_METHOD_LOOKUP` matches "
                 "source raster file: {}".format(rasterfile_src)
             )
+
+        if rasterfile_src.endswith(('ortho.tif', 'ortho2.tif')) or 'bitmask' in rasterfile_src:
+            predictor = 2
+        else:
+            predictor = 1
+
         commands.append(
             ('gdalwarp "{0}" "{1}" -q -tap -t_srs EPSG:{2} -tr {3} {3} -r {4} {5} '
-             '-overwrite -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW'.format(
-                rasterfile_src, rasterfile_dst,
-                target_epsg, rasterfile_dst_res, resample_method,
-                '-dstnodata 1' if 'bitmask' in rasterfile_src else ''
+             '-overwrite -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW -co PREDICTOR={6}'.format(
+                rasterfile_src,
+                rasterfile_dst if rasterfile_dst_uncompressed is None else rasterfile_dst_uncompressed,
+                target_epsg,
+                rasterfile_dst_res,
+                resample_method,
+                '-dstnodata 1' if 'bitmask' in rasterfile_src else '',
+                predictor,
             ))
         )
-        if 'bitmask' in rasterfile_src:
+
+        if rasterfile_src.endswith('dem.tif'):
+            commands.append(
+                ('gdal_calc.py --quiet --overwrite -A "{0}" --outfile="{1}" --calc="round_(A*128.0)/128.0" --NoDataValue=-9999'
+                 ' --co TILED=YES --co BIGTIFF=IF_SAFER --co COMPRESS=LZW --co PREDICTOR=3'.format(rasterfile_dst_uncompressed, rasterfile_dst))
+            )
+        elif 'bitmask' in rasterfile_src:
             commands.append('gdal_edit.py -unsetnodata {}'.format(rasterfile_dst))
 
     for cmd in commands:
@@ -765,6 +790,7 @@ def saveStripBrowse(args, demFile, demSuffix, maskSuffix):
     ortho2File_10m     = demFile.replace(demSuffix, 'ortho2_10m.tif')
     matchFile_10m      = demFile.replace(demSuffix, 'matchtag_10m.tif')
     demFile_10m        = demFile.replace(demSuffix, 'dem_10m.tif')
+    demFile_10m_temp   = demFile.replace(demSuffix, 'dem_10m_temp.tif')
     demFile_10m_masked = demFile.replace(demSuffix, 'dem_10m_masked.tif')
     demFile_10m_shade  = demFile.replace(demSuffix, 'dem_10m_shade.tif')
     demFile_shade_mask = demFile.replace(demSuffix, 'dem_10m_shade_masked.tif')
@@ -778,6 +804,7 @@ def saveStripBrowse(args, demFile, demSuffix, maskSuffix):
         output_files.update([
             maskFile_10m,
             demFile_10m,
+            demFile_10m_temp,
             demFile_10m_shade,
             demFile_shade_mask
         ])
@@ -793,6 +820,7 @@ def saveStripBrowse(args, demFile, demSuffix, maskSuffix):
             orthoFile_10m,
             matchFile_10m,
             demFile_10m,
+            demFile_10m_temp,
             demFile_10m_shade,
             demFile_10m_masked,
             demFile_shade_mask,
@@ -842,7 +870,11 @@ def saveStripBrowse(args, demFile, demSuffix, maskSuffix):
     if demFile_10m in output_files:
         commands.append(
             ('gdalwarp "{0}" "{1}" -q -overwrite -tr {2} {2} -r bilinear -dstnodata -9999'
-             ' -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW'.format(demFile, demFile_10m, 10))
+             ' -co TILED=YES -co BIGTIFF=IF_SAFER -co COMPRESS=LZW'.format(demFile, demFile_10m_temp, 10))
+        )
+        commands.append(
+            ('gdal_calc.py --quiet --overwrite -A "{0}" --outfile="{1}" --calc="round_(A*128.0)/128.0" --NoDataValue=-9999'
+             ' --co TILED=YES --co BIGTIFF=IF_SAFER --co COMPRESS=LZW --co PREDICTOR=3'.format(demFile_10m_temp, demFile_10m))
         )
     if demFile_10m_shade in output_files:
         commands.append(


### PR DESCRIPTION
- Output full-res and 10m-res strip DEM rasters have values rounded to 1/128 meters to improve floating point compression effectiveness.
- Add GDAL creation option `PREDICTOR` setting for better integer and float raster compression.