### PR TITLE
Add licenses

### DIFF
--- a/batch_check_setsm.py
+++ b/batch_check_setsm.py
@@ -854,13 +854,12 @@ def argparser_init():
         nargs='?',
         help="Send email to user upon end or abort of the LAST SUBMITTED task."
     )
-
     parser.add_argument(
         ARGSTR_LICENSES,
         type=script_utils.ARGTYPE_BOOL_PLUS(
             parse_fn=str),
         nargs='?',
-        help="Licenses argument to pass to slurm"
+        help="Licenses argument to pass to slurm."
     )
 
     parser.add_argument(

--- a/batch_check_setsm.py
+++ b/batch_check_setsm.py
@@ -105,13 +105,14 @@ ARGSTR_SCRATCH = '--scratch'
 ARGSTR_WD = '--wd'
 ARGSTR_LOGDIR = '--logdir'
 ARGSTR_EMAIL = '--email'
+ARGSTR_LICENSES = '--licenses'
 ARGSTR_DO_DELETE = '--do-delete'
 ARGSTR_DRYRUN = '--dryrun'
 ARGSTR_DEBUG = '--debug'
 
 # Argument groups
 ARGGRP_OUTDIR = [ARGSTR_LOGDIR, ARGSTR_SCRATCH]
-ARGGRP_BATCH = [ARGSTR_SCHEDULER, ARGSTR_JOBSCRIPT, ARGSTR_TASKS_PER_JOB, ARGSTR_EMAIL]
+ARGGRP_BATCH = [ARGSTR_SCHEDULER, ARGSTR_JOBSCRIPT, ARGSTR_TASKS_PER_JOB, ARGSTR_EMAIL, ARGSTR_LICENSES]
 ARGGRP_CHECK_REGULAR = [ARGSTR_CHECKFILE, ARGSTR_CHECKFILE_ROOT, ARGSTR_CHECKFILE_ROOT_REGEX]
 ARGGRP_CHECK_OTHER = [ARGSTR_CHECK_SPECIAL]
 ARGGRP_CHECK_ALL = ARGGRP_CHECK_REGULAR + ARGGRP_CHECK_OTHER
@@ -852,6 +853,14 @@ def argparser_init():
             parse_fn=str),
         nargs='?',
         help="Send email to user upon end or abort of the LAST SUBMITTED task."
+    )
+
+    parser.add_argument(
+        ARGSTR_LICENSES,
+        type=script_utils.ARGTYPE_BOOL_PLUS(
+            parse_fn=str),
+        nargs='?',
+        help="Licenses argument to pass to slurm"
     )
 
     parser.add_argument(
@@ -1824,7 +1833,7 @@ def main():
                 jobscript=args_batch.get(ARGSTR_JOBSCRIPT), jobname=job_name,
                 time_hr=JOB_WALLTIME_HR, memory_gb=JOB_MEMORY_GB,
                 node=job_node_single, ncores=JOB_NCORES,
-                email=args.get(ARGSTR_EMAIL),
+                email=args.get(ARGSTR_EMAIL), licenses=args.get(ARGSTR_LICENSES),
                 envvars=[args_batch.get(ARGSTR_JOBSCRIPT), JOB_ABBREV, cmd_single, PYTHON_VERSION_ACCEPTED_MIN],
                 hold=False
             )

--- a/batch_mask.py
+++ b/batch_mask.py
@@ -73,6 +73,7 @@ ARGSTR_TASKS_PER_JOB = '--tasks-per-job'
 ARGSTR_SCRATCH = '--scratch'
 ARGSTR_LOGDIR = '--logdir'
 ARGSTR_EMAIL = '--email'
+ARGSTR_LICENSES = '--licenses'
 ARGSTR_DRYRUN = '--dryrun'
 
 # Argument choices
@@ -96,7 +97,7 @@ ARGDEF_SCRATCH = os.path.join(os.path.expanduser('~'), 'scratch', 'task_bundles'
 
 # Argument groups
 ARGGRP_OUTDIR = [ARGSTR_DSTDIR, ARGSTR_LOGDIR, ARGSTR_SCRATCH]
-ARGGRP_BATCH = [ARGSTR_SCHEDULER, ARGSTR_JOBSCRIPT, ARGSTR_TASKS_PER_JOB, ARGSTR_EMAIL]
+ARGGRP_BATCH = [ARGSTR_SCHEDULER, ARGSTR_JOBSCRIPT, ARGSTR_TASKS_PER_JOB, ARGSTR_EMAIL, ARGSTR_LICENSES]
 ARGGRP_FILTER_COMP = [ARGSTR_EDGE, ARGSTR_WATER, ARGSTR_CLOUD]
 
 ##############################
@@ -341,6 +342,13 @@ def argparser_init():
             parse_fn=str),
         nargs='?',
         help="Send email to user upon end or abort of the LAST SUBMITTED task."
+    )
+    parser.add_argument(
+        ARGSTR_LICENSES,
+        type=script_utils.ARGTYPE_BOOL_PLUS(
+            parse_fn=str),
+        nargs='?',
+        help="Licenses argument to pass to slurm."
     )
 
     parser.add_argument(
@@ -738,7 +746,7 @@ def main():
                 jobscript=args_batch.get(ARGSTR_JOBSCRIPT), jobname=job_name,
                 time_hr=JOB_WALLTIME_HR, memory_gb=JOB_MEMORY_GB,
                 node=job_node_single, ncores=JOB_NCORES,
-                email=args.get(ARGSTR_EMAIL),
+                email=args.get(ARGSTR_EMAIL), licenses=args.get(ARGSTR_LICENSES),
                 envvars=[args_batch.get(ARGSTR_JOBSCRIPT), JOB_ABBREV, cmd_single, PYTHON_VERSION_ACCEPTED_MIN],
             )
 

--- a/batch_scenes2strips.py
+++ b/batch_scenes2strips.py
@@ -78,6 +78,7 @@ ARGSTR_SCHEDULER = '--scheduler'
 ARGSTR_JOBSCRIPT = '--jobscript'
 ARGSTR_LOGDIR = '--logdir'
 ARGSTR_EMAIL = '--email'
+ARGSTR_LICENSES = '--licenses'
 ARGSTR_RESTART = '--restart'
 ARGSTR_REMOVE_INCOMPLETE = '--remove-incomplete'
 ARGSTR_USE_OLD_MASKS = '--use-old-masks'
@@ -146,7 +147,7 @@ MASK_VER_XM = [
 
 # Argument groups
 ARGGRP_OUTDIR = [ARGSTR_DST, ARGSTR_LOGDIR]
-ARGGRP_BATCH = [ARGSTR_SCHEDULER, ARGSTR_JOBSCRIPT, ARGSTR_LOGDIR, ARGSTR_EMAIL]
+ARGGRP_BATCH = [ARGSTR_SCHEDULER, ARGSTR_JOBSCRIPT, ARGSTR_LOGDIR, ARGSTR_EMAIL, ARGSTR_LICENSES]
 ARGGRP_UNFILTERED = [ARGSTR_NOWATER, ARGSTR_NOCLOUD]
 ARGGRP_META_ONLY = [ARGSTR_SINGLE_SCENE_STRIPS, ARGSTR_USE_OLD_MASKS, ARGSTR_NOFILTER_COREG, (ARGSTR_CLEANUP_ON_FAILURE, ARGCHO_CLEANUP_ON_FAILURE_NONE)]
 ARGGRP_SINGLE_SCENE_STRIPS = [ARGSTR_USE_OLD_MASKS, ARGSTR_NOFILTER_COREG, (ARGSTR_CLEANUP_ON_FAILURE, ARGCHO_CLEANUP_ON_FAILURE_STRIP)]
@@ -514,6 +515,13 @@ def argparser_init():
             parse_fn=str),
         nargs='?',
         help="Send email to user upon end or abort of the LAST SUBMITTED task."
+    )
+    parser.add_argument(
+        ARGSTR_LICENSES,
+        type=script_utils.ARGTYPE_BOOL_PLUS(
+            parse_fn=str),
+        nargs='?',
+        help="Licenses argument to pass to slurm."
     )
 
     parser.add_argument(
@@ -934,7 +942,7 @@ def main():
                     jobscript=args_batch.get(ARGSTR_JOBSCRIPT), jobname=job_name,
                     time_hr=JOB_WALLTIME_HR, memory_gb=JOB_MEMORY_GB,
                     node=job_node_single, ncores=JOB_NCORES,
-                    email=args.get(ARGSTR_EMAIL),
+                    email=args.get(ARGSTR_EMAIL), licenses=args.get(ARGSTR_LICENSES),
                     envvars=[args_batch.get(ARGSTR_JOBSCRIPT), JOB_ABBREV, cmd_single, PYTHON_VERSION_ACCEPTED_MIN],
                 )
             else:

--- a/lib/script_utils.py
+++ b/lib/script_utils.py
@@ -643,7 +643,7 @@ class ArgumentPasser:
                           jobscript=None, jobname=None,
                           time_hr=None, time_min=None, time_sec=None,
                           node=None, ncores=None, memory_gb=None,
-                          email=None,
+                          email=None, licenses=None,
                           envvars=None, hold=False):
         cmd = None
         cmd_envvars = None
@@ -702,6 +702,7 @@ class ArgumentPasser:
                 "--export {}".format(cmd_envvars) if cmd_envvars is not None else '',
                 "--mail-type FAIL,END" if email else '',
                 "--mail-user {}".format(email) if type(email) is str else '',
+                "--licenses={}".format(licenses) if type(licenses) is str else '',
             ])
             jobscript_optkey = '#SBATCH'
 


### PR DESCRIPTION
Add a `--licenses` argument to the batch scripts to allow limiting the number of simultaneously running instances are allowed at a time (to avoid overrunning storage IO capabilities).

Thinking more broadly, this maybe would be better implemented as a generic 'pass these things to the scheduler' that could handle switching queues/partitions or any other option too.